### PR TITLE
feat(catalog): implement GetCategoryById query endpoint

### DIFF
--- a/src/Ecommerce.AppHost/Program.cs
+++ b/src/Ecommerce.AppHost/Program.cs
@@ -1,4 +1,5 @@
 using Ecommerce.AppHost.Modules;
+using Ecommerce.AppHost.Scalar;
 using Ecommerce.Shared.API;
 using MicroElements.AspNetCore.OpenApi.FluentValidation;
 using Scalar.AspNetCore;
@@ -16,6 +17,7 @@ internal static class Program
         builder.Services.AddOpenApi(options =>
         {
             options.AddFluentValidationRules();
+            options.AddDocumentTransformer<RemoveRequiredFromResponseTransformer>();
         });
 
         var app = builder.Build();
@@ -23,7 +25,15 @@ internal static class Program
         if (app.Environment.IsDevelopment())
         {
             app.MapOpenApi();
-            app.MapScalarApiReference();
+            app.MapScalarApiReference( options =>
+                {
+                    options.WithTitle("Ecommerce API Documentation");
+                    options.DotNetFlag = true;
+                    options.HideModels = true;
+                    options.HideClientButton = true;
+                    options.DefaultOpenAllTags = false;
+                }
+            );
         }
 
         app.UseHttpsRedirection();

--- a/src/Ecommerce.AppHost/Scalar/RemoveRequiredFromResponseTransformer.cs
+++ b/src/Ecommerce.AppHost/Scalar/RemoveRequiredFromResponseTransformer.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace Ecommerce.AppHost.Scalar;
+
+public class RemoveRequiredFromResponseTransformer : IOpenApiDocumentTransformer
+{
+    public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        foreach (var path in document.Paths)
+        {
+            var operations = path.Value.Operations ??
+                             new Dictionary<HttpMethod, OpenApiOperation>();
+
+            foreach (var operation in operations)
+            {
+                var responses = operation.Value.Responses;
+                if (responses is null) continue;
+
+                foreach (var response in responses)
+                {
+                    var content = response.Value.Content;
+                    if (content is null) continue;
+
+                    foreach (var mediaType in content.Values)
+                    {
+                        mediaType.Schema?.Required?.Clear();
+                    }
+                }
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Ecommerce.Catalog/Ecommerce.Catalog.Api/Categories/CategoriesController.cs
+++ b/src/Ecommerce.Catalog/Ecommerce.Catalog.Api/Categories/CategoriesController.cs
@@ -1,5 +1,7 @@
 using Ecommerce.Catalog.Api.Categories.CreateCategory;
+using Ecommerce.Catalog.Api.Categories.GetCategoryById;
 using Ecommerce.Catalog.Application;
+using Ecommerce.Catalog.Application.Categories.GetCategoryById;
 using Ecommerce.Shared.API.Exceptions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -25,11 +27,12 @@ public sealed class CategoriesController(ICatalogModule module) : ControllerBase
 
     [HttpGet("{id:int}")]
     [EndpointDescription("Returns a category by its ID.")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType<ProblemDetails>(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<GetCategoryByIdResponse>(StatusCodes.Status200OK)]
     [ProducesResponseType<ValidationProblemDetails>(StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> GetById(int id, CancellationToken cancellationToken)
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetById([FromRoute] int id, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var result = await module.ExecuteQueryAsync(new GetCategoryByIdQuery(id), cancellationToken);
+        return Ok(GetCategoryByIdResponse.FromResult(result));
     }
 }

--- a/src/Ecommerce.Catalog/Ecommerce.Catalog.Api/Categories/GetCategoryById/GetCategoryByIdResponse.cs
+++ b/src/Ecommerce.Catalog/Ecommerce.Catalog.Api/Categories/GetCategoryById/GetCategoryByIdResponse.cs
@@ -1,0 +1,14 @@
+using Ecommerce.Catalog.Application.Categories.GetCategoryById;
+
+namespace Ecommerce.Catalog.Api.Categories.GetCategoryById;
+
+public sealed record GetCategoryByIdResponse(
+    int Id,
+    string Name,
+    string Slug,
+    string? Description,
+    bool IsActive)
+{
+    internal static GetCategoryByIdResponse FromResult(GetCategoryByIdResult result) =>
+        new(result.Id, result.Name, result.Slug, result.Description, result.IsActive);
+}

--- a/src/Ecommerce.Catalog/Ecommerce.Catalog.Application/Categories/GetCategoryById/CategoryMustExistRule.cs
+++ b/src/Ecommerce.Catalog/Ecommerce.Catalog.Application/Categories/GetCategoryById/CategoryMustExistRule.cs
@@ -1,0 +1,13 @@
+using Ecommerce.Catalog.Domain.Entities;
+using Ecommerce.Shared.Application.Exceptions;
+using Ecommerce.Shared.Domain.BusinessRules;
+
+namespace Ecommerce.Catalog.Application.Categories.GetCategoryById;
+
+public class CategoryMustExistRule(Category? category) : IBusinessRule
+{
+    public bool IsMet() => category is not null;
+
+    public Exception CreateException() =>
+        new ResourceNotFoundException(CategoryConsts.NotFoundError);
+}

--- a/src/Ecommerce.Catalog/Ecommerce.Catalog.Application/Categories/GetCategoryById/GetCategoryByIdHandler.cs
+++ b/src/Ecommerce.Catalog/Ecommerce.Catalog.Application/Categories/GetCategoryById/GetCategoryByIdHandler.cs
@@ -1,0 +1,22 @@
+using Ecommerce.Catalog.Domain.Repositories;
+using Ecommerce.Shared.Domain.BusinessRules;
+using MediatR;
+
+namespace Ecommerce.Catalog.Application.Categories.GetCategoryById;
+
+internal sealed class GetCategoryByIdHandler(ICatalogRepository repository)
+    : IRequestHandler<GetCategoryByIdQuery, GetCategoryByIdResult>
+{
+    public async Task<GetCategoryByIdResult> Handle(GetCategoryByIdQuery query, CancellationToken cancellationToken)
+    {
+        var category = await repository.GetByIdAsync(query.Id, cancellationToken);
+        BusinessRule.Validate(new CategoryMustExistRule(category));
+
+        return new GetCategoryByIdResult(
+            category!.Id,
+            category.Name,
+            category.Slug,
+            category.Description,
+            category.IsActive);
+    }
+}

--- a/src/Ecommerce.Catalog/Ecommerce.Catalog.Application/Categories/GetCategoryById/GetCategoryByIdQuery.cs
+++ b/src/Ecommerce.Catalog/Ecommerce.Catalog.Application/Categories/GetCategoryById/GetCategoryByIdQuery.cs
@@ -1,0 +1,5 @@
+using Ecommerce.Shared.Application.CQRS;
+
+namespace Ecommerce.Catalog.Application.Categories.GetCategoryById;
+
+public sealed record GetCategoryByIdQuery(int Id) : IQuery<GetCategoryByIdResult>;

--- a/src/Ecommerce.Catalog/Ecommerce.Catalog.Application/Categories/GetCategoryById/GetCategoryByIdResult.cs
+++ b/src/Ecommerce.Catalog/Ecommerce.Catalog.Application/Categories/GetCategoryById/GetCategoryByIdResult.cs
@@ -1,0 +1,8 @@
+namespace Ecommerce.Catalog.Application.Categories.GetCategoryById;
+
+public sealed record GetCategoryByIdResult(
+    int Id,
+    string Name,
+    string Slug,
+    string? Description,
+    bool IsActive);

--- a/src/Ecommerce.Catalog/Ecommerce.Catalog.Domain/Entities/CategoryConsts.cs
+++ b/src/Ecommerce.Catalog/Ecommerce.Catalog.Domain/Entities/CategoryConsts.cs
@@ -9,4 +9,5 @@ public static class CategoryConsts
     public const int DescriptionMaxLength = 500;
 
     public const string NameDuplicateError = "A category with this name already exists.";
+    public const string NotFoundError = "Category not found.";
 }

--- a/src/Ecommerce.Shared/Ecommerce.Shared.Application/Exceptions/ResourceNotFoundException.cs
+++ b/src/Ecommerce.Shared/Ecommerce.Shared.Application/Exceptions/ResourceNotFoundException.cs
@@ -2,8 +2,8 @@ using Ecommerce.Shared.Domain.Exceptions;
 
 namespace Ecommerce.Shared.Application.Exceptions;
 
-public class ResourceAlreadyExistsException(string message) : Exception(message), IAppException
+public class ResourceNotFoundException(string message) : Exception(message), IAppException
 {
-    public int StatusCode => 409;
+    public int StatusCode => 404;
     public string ErrorMessage => Message;
 }

--- a/src/Ecommerce.Shared/Ecommerce.Shared.Domain/Repositories/IRepository.cs
+++ b/src/Ecommerce.Shared/Ecommerce.Shared.Domain/Repositories/IRepository.cs
@@ -5,7 +5,6 @@ namespace Ecommerce.Shared.Domain.Repositories;
 public interface IRepository<T> where T : Entity
 {
     Task<T?> GetByIdAsync(int id, CancellationToken ct = default);
-    Task<T?> GetByIdAsNoTrackingAsync(int id, CancellationToken ct = default);
     void Add(T entity);
     void Update(T entity);
     void Remove(T entity);

--- a/src/Ecommerce.Shared/Ecommerce.Shared.Infrastructure/Persistence/Repository.cs
+++ b/src/Ecommerce.Shared/Ecommerce.Shared.Infrastructure/Persistence/Repository.cs
@@ -13,9 +13,6 @@ public abstract class Repository<T, TContext>(TContext context) : IRepository<T>
     public async Task<T?> GetByIdAsync(int id, CancellationToken ct = default) =>
         await Context.Set<T>().FindAsync([id], ct);
 
-    public async Task<T?> GetByIdAsNoTrackingAsync(int id, CancellationToken ct = default) =>
-        await Context.Set<T>().AsNoTracking().SingleOrDefaultAsync(e => e.Id == id, ct);
-
     public void Add(T entity)
     {
         Context.Set<T>().Add(entity);


### PR DESCRIPTION
## Summary

- Rewrite Scalar OpenAPI config and response transformer to use native `IOpenApiDocumentTransformer`
- Clean up shared repository (remove unused `GetByIdAsNoTrackingAsync`, fix `ResourceAlreadyExistsException` base class, add `ResourceNotFoundException`)
- Implement `GET /categories/{id}` endpoint with CQRS query pattern and `CategoryMustExistRule` business rule

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)