### PR TITLE
feat: load production secrets from azure key vault

### DIFF
--- a/src/Ecommerce.AppHost/Ecommerce.AppHost.csproj
+++ b/src/Ecommerce.AppHost/Ecommerce.AppHost.csproj
@@ -5,6 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
+        <PackageReference Include="Azure.Identity" Version="1.14.2" />
         <PackageReference Include="MicroElements.AspNetCore.OpenApi.FluentValidation" Version="7.1.7-beta.3" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.14.14" />

--- a/src/Ecommerce.AppHost/Program.cs
+++ b/src/Ecommerce.AppHost/Program.cs
@@ -1,3 +1,4 @@
+using Azure.Identity;
 using Ecommerce.AppHost.Authorization;
 using Ecommerce.AppHost.Modules;
 using Ecommerce.AppHost.Scalar;
@@ -15,6 +16,17 @@ internal static class Program
     public static void Main(string[] args)
     {
         var builder = WebApplication.CreateBuilder(args);
+
+        if (builder.Environment.IsProduction())
+        {
+            var vaultUri = builder.Configuration["KeyVault:VaultUri"];
+            if (string.IsNullOrWhiteSpace(vaultUri))
+            {
+                throw new InvalidOperationException("KeyVault:VaultUri must be set in Production.");
+            }
+
+            builder.Configuration.AddAzureKeyVault(new Uri(vaultUri), new DefaultAzureCredential());
+        }
 
         builder.Services.AddKernelInfrastructure(builder.Configuration);
         builder.Services.AddApiModule(builder.Configuration);

--- a/src/Ecommerce.AppHost/appsettings.json
+++ b/src/Ecommerce.AppHost/appsettings.json
@@ -24,6 +24,9 @@
   "Cors": {
     "AllowedOrigins": [ "https://admin-ecommerce.marcuscfarias.com" ]
   },
+  "KeyVault": {
+    "VaultUri": ""
+  },
   "ConnectionStrings": {
     "EcommerceDb": ""
   },


### PR DESCRIPTION
Production-only Key Vault config provider via the existing managed identity. Vault, secrets, role, and `KeyVault__VaultUri` are already provisioned; ACA secret cutover stays for after this image deploys.